### PR TITLE
Add trade analytics service and stats endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # trade-tracker
+
+Simple analytics service for aggregating trade metrics. Provides `/stats` endpoint to compute statistics over trades filtered by date range and tags.
+
+## Running the API
+
+```bash
+pip install -r requirements.txt
+uvicorn trade_tracker.main:app --reload
+```
+
+## Running Tests
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pydantic
+pytest

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+import pytest
+
+from trade_tracker.analytics import calculate_stats
+from trade_tracker.data import TRADES
+
+
+def test_calculate_stats_filters():
+    start = datetime(2024, 1, 1)
+    end = datetime(2024, 1, 3)
+    stats = calculate_stats(TRADES, start=start, end=end, tags=["tech"])
+    assert stats["trade_count"] == 1
+    assert stats["total_quantity"] == 5
+    assert stats["average_price"] == 100
+
+
+def test_calculate_stats_all():
+    stats = calculate_stats(TRADES)
+    assert stats["trade_count"] == 3
+    assert stats["total_quantity"] == 10
+    assert stats["average_price"] == pytest.approx(107.0)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+
+from trade_tracker.main import app
+
+
+def test_stats_endpoint():
+    client = TestClient(app)
+    response = client.get("/stats", params={"start": "2024-01-01", "end": "2024-01-03", "tags": "tech"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["trade_count"] == 1
+    assert data["total_quantity"] == 5
+    assert data["average_price"] == 100

--- a/trade_tracker/analytics.py
+++ b/trade_tracker/analytics.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from typing import Iterable, List, Optional, Sequence
+
+from .models import Trade
+
+
+def _filter_trades(
+    trades: Iterable[Trade],
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    tags: Optional[Sequence[str]] = None,
+) -> List[Trade]:
+    """Filter trades by date range and tags."""
+    result: List[Trade] = []
+    tag_set = set(tags or [])
+    for trade in trades:
+        if start and trade.timestamp < start:
+            continue
+        if end and trade.timestamp > end:
+            continue
+        if tag_set and not tag_set.issubset(trade.tags):
+            continue
+        result.append(trade)
+    return result
+
+
+def calculate_stats(
+    trades: Iterable[Trade],
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    tags: Optional[Sequence[str]] = None,
+) -> dict:
+    """Aggregate trades and return key metrics."""
+    filtered = _filter_trades(trades, start=start, end=end, tags=tags)
+    total_quantity = sum(t.quantity for t in filtered)
+    total_value = sum(t.price * t.quantity for t in filtered)
+    trade_count = len(filtered)
+    average_price = total_value / total_quantity if total_quantity else 0
+    return {
+        "trade_count": trade_count,
+        "total_quantity": total_quantity,
+        "average_price": average_price,
+    }

--- a/trade_tracker/data.py
+++ b/trade_tracker/data.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+from .models import Trade
+
+# Sample trades dataset
+TRADES = [
+    Trade(id=1, timestamp=datetime(2024, 1, 1, 10), quantity=5, price=100, tags=["tech", "buy"]),
+    Trade(id=2, timestamp=datetime(2024, 1, 2, 11), quantity=3, price=110, tags=["sell"]),
+    Trade(id=3, timestamp=datetime(2024, 1, 5, 9), quantity=2, price=120, tags=["tech", "sell"]),
+]

--- a/trade_tracker/main.py
+++ b/trade_tracker/main.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import FastAPI, Query
+
+from .analytics import calculate_stats
+from .data import TRADES
+
+app = FastAPI()
+
+
+@app.get("/stats")
+def stats(
+    start: Optional[datetime] = Query(None),
+    end: Optional[datetime] = Query(None),
+    tags: Optional[str] = Query(None),
+):
+    """Return aggregated trade statistics."""
+    tag_list: List[str] = tags.split(",") if tags else []
+    return calculate_stats(TRADES, start=start, end=end, tags=tag_list)

--- a/trade_tracker/models.py
+++ b/trade_tracker/models.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from typing import List
+from pydantic import BaseModel
+
+
+class Trade(BaseModel):
+    """Represents a trade entry."""
+    id: int
+    timestamp: datetime
+    quantity: float
+    price: float
+    tags: List[str]


### PR DESCRIPTION
## Summary
- implement Trade model and analytics service to aggregate trades by date and tags
- expose `/stats` endpoint to retrieve aggregated metrics
- cover analytics and API behavior with unit tests

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68b79d175698832d919ce98df11d507e