### PR TITLE
Add FastAPI backend with Supabase PostgreSQL integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 trades.json
+__pycache__/
+*.pyc

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,73 @@
+import os
+import asyncpg
+from typing import Any, Dict, List
+
+_pool: asyncpg.Pool | None = None
+
+async def init_db() -> asyncpg.Pool:
+    """Initialize the database connection pool using Supabase credentials."""
+    global _pool
+    if _pool is None:
+        _pool = await asyncpg.create_pool(
+            user=os.getenv("SUPABASE_DB_USER"),
+            password=os.getenv("SUPABASE_DB_PASSWORD"),
+            host=os.getenv("SUPABASE_DB_HOST"),
+            port=int(os.getenv("SUPABASE_DB_PORT", "5432")),
+            database=os.getenv("SUPABASE_DB_NAME"),
+        )
+    return _pool
+
+async def create_trade(trade: Dict[str, Any]) -> int:
+    pool = await init_db()
+    query = (
+        "INSERT INTO trades (id, symbol, side, qty, entry_price, entry_time, "
+        "exit_price, exit_time, fees, tags, notes)"
+        " VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11) RETURNING id"
+    )
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            query,
+            trade.get("id"),
+            trade["symbol"],
+            trade["side"],
+            trade["qty"],
+            trade["entry_price"],
+            trade["entry_time"],
+            trade.get("exit_price"),
+            trade.get("exit_time"),
+            trade.get("fees"),
+            trade.get("tags"),
+            trade.get("notes"),
+        )
+
+async def get_trades() -> List[asyncpg.Record]:
+    pool = await init_db()
+    async with pool.acquire() as conn:
+        return await conn.fetch("SELECT * FROM trades ORDER BY id")
+
+async def update_trade(trade_id: int, trade: Dict[str, Any]) -> None:
+    pool = await init_db()
+    query = (
+        "UPDATE trades SET symbol=$1, side=$2, qty=$3, entry_price=$4, entry_time=$5,"
+        " exit_price=$6, exit_time=$7, fees=$8, tags=$9, notes=$10 WHERE id=$11"
+    )
+    async with pool.acquire() as conn:
+        await conn.execute(
+            query,
+            trade["symbol"],
+            trade["side"],
+            trade["qty"],
+            trade["entry_price"],
+            trade["entry_time"],
+            trade.get("exit_price"),
+            trade.get("exit_time"),
+            trade.get("fees"),
+            trade.get("tags"),
+            trade.get("notes"),
+            trade_id,
+        )
+
+async def delete_trade(trade_id: int) -> None:
+    pool = await init_db()
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM trades WHERE id=$1", trade_id)

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -1,0 +1,15 @@
+import asyncio
+from pathlib import Path
+
+from .db import init_db
+
+async def run() -> None:
+    pool = await init_db()
+    schema_path = Path(__file__).resolve().parent.parent / "schema.sql"
+    with open(schema_path, "r", encoding="utf-8") as f:
+        schema_sql = f.read()
+    async with pool.acquire() as conn:
+        await conn.execute(schema_sql)
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI, HTTPException
+from typing import List
+
+from .db import create_trade, get_trades, update_trade, delete_trade, init_db
+from .models import Trade
+
+app = FastAPI()
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    await init_db()
+
+@app.post("/trades", response_model=int)
+async def create_trade_route(trade: Trade) -> int:
+    return await create_trade(trade.dict())
+
+@app.get("/trades", response_model=List[Trade])
+async def get_trades_route() -> List[Trade]:
+    records = await get_trades()
+    return [Trade(**dict(record)) for record in records]
+
+@app.put("/trades/{trade_id}")
+async def update_trade_route(trade_id: int, trade: Trade) -> None:
+    if trade_id != trade.id:
+        raise HTTPException(status_code=400, detail="Trade ID mismatch")
+    await update_trade(trade_id, trade.dict())
+
+@app.delete("/trades/{trade_id}")
+async def delete_trade_route(trade_id: int) -> None:
+    await delete_trade(trade_id)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class Trade(BaseModel):
+    id: int
+    symbol: str
+    side: str
+    qty: float
+    entry_price: float
+    entry_time: str
+    exit_price: Optional[float] = None
+    exit_time: Optional[str] = None
+    fees: Optional[float] = None
+    tags: Optional[str] = None
+    notes: Optional[str] = None


### PR DESCRIPTION
## Summary
- create asynchronous db module using Supabase credentials
- implement FastAPI CRUD endpoints for trades
- include script to initialize database schema

## Testing
- `pytest`
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b834828d08832da0aad86fe3a999d8