### PR TITLE
Add FastAPI backend with SQLite persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trade Tracker
 
-Simple trade tracking service with a tiny Node.js backend and static dashboard.
+Simple trade tracking service with a FastAPI backend and static dashboard.
 
 ## Planned Tech Stack
 The project is evolving toward a modern stack that supports option strategy analytics and richer workflows:
@@ -38,9 +38,17 @@ The application uses a `trades` table with the following columns:
 - `DELETE /trades/:id` – remove a trade
 
 ## Development
+### Backend (FastAPI)
+Install dependencies and start the API server:
 ```
-npm install  # no external dependencies
-npm start    # start server at http://localhost:3000
+pip install fastapi uvicorn
+uvicorn backend.app.main:app --reload
+```
+
+### Frontend
+```
+npm install
+npm start
 ```
 
 Run tests:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,129 @@
+from fastapi import FastAPI, HTTPException, Depends
+from pydantic import BaseModel
+from typing import List, Optional, Generator
+import sqlite3
+from pathlib import Path
+import uvicorn
+
+ROOT = Path(__file__).resolve().parents[2]
+DB_PATH = ROOT / "trades.db"
+SCHEMA_PATH = ROOT / "schema.sql"
+
+app = FastAPI()
+
+def init_db() -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        with open(SCHEMA_PATH) as f:
+            conn.executescript(f.read())
+        conn.commit()
+
+def get_db() -> Generator[sqlite3.Connection, None, None]:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
+
+class TradeBase(BaseModel):
+    symbol: str
+    side: str
+    qty: float
+    entry_price: float
+    entry_time: str
+    exit_price: Optional[float] = None
+    exit_time: Optional[str] = None
+    fees: Optional[float] = None
+    tags: Optional[str] = None
+    notes: Optional[str] = None
+
+class TradeCreate(TradeBase):
+    pass
+
+class TradeUpdate(BaseModel):
+    symbol: Optional[str] = None
+    side: Optional[str] = None
+    qty: Optional[float] = None
+    entry_price: Optional[float] = None
+    entry_time: Optional[str] = None
+    exit_price: Optional[float] = None
+    exit_time: Optional[str] = None
+    fees: Optional[float] = None
+    tags: Optional[str] = None
+    notes: Optional[str] = None
+
+class Trade(TradeBase):
+    id: int
+
+@app.get("/trades", response_model=List[Trade])
+def list_trades(db: sqlite3.Connection = Depends(get_db)) -> List[Trade]:
+    rows = db.execute("SELECT * FROM trades").fetchall()
+    return [Trade(**dict(row)) for row in rows]
+
+@app.post("/trades", response_model=Trade, status_code=201)
+def create_trade(trade: TradeCreate, db: sqlite3.Connection = Depends(get_db)) -> Trade:
+    cursor = db.execute(
+        """
+        INSERT INTO trades (symbol, side, qty, entry_price, entry_time, exit_price, exit_time, fees, tags, notes)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            trade.symbol,
+            trade.side,
+            trade.qty,
+            trade.entry_price,
+            trade.entry_time,
+            trade.exit_price,
+            trade.exit_time,
+            trade.fees,
+            trade.tags,
+            trade.notes,
+        ),
+    )
+    db.commit()
+    return Trade(id=cursor.lastrowid, **trade.dict())
+
+@app.put("/trades/{trade_id}", response_model=Trade)
+def update_trade(trade_id: int, trade: TradeUpdate, db: sqlite3.Connection = Depends(get_db)) -> Trade:
+    existing = db.execute("SELECT * FROM trades WHERE id = ?", (trade_id,)).fetchone()
+    if not existing:
+        raise HTTPException(status_code=404, detail="Trade not found")
+    data = {**dict(existing), **trade.dict(exclude_unset=True)}
+    db.execute(
+        """
+        UPDATE trades SET symbol=?, side=?, qty=?, entry_price=?, entry_time=?, exit_price=?, exit_time=?, fees=?, tags=?, notes=?
+        WHERE id=?
+        """,
+        (
+            data["symbol"],
+            data["side"],
+            data["qty"],
+            data["entry_price"],
+            data["entry_time"],
+            data.get("exit_price"),
+            data.get("exit_time"),
+            data.get("fees"),
+            data.get("tags"),
+            data.get("notes"),
+            trade_id,
+        ),
+    )
+    db.commit()
+    updated = db.execute("SELECT * FROM trades WHERE id = ?", (trade_id,)).fetchone()
+    return Trade(**dict(updated))
+
+@app.delete("/trades/{trade_id}", response_model=Trade)
+def delete_trade(trade_id: int, db: sqlite3.Connection = Depends(get_db)) -> Trade:
+    existing = db.execute("SELECT * FROM trades WHERE id = ?", (trade_id,)).fetchone()
+    if not existing:
+        raise HTTPException(status_code=404, detail="Trade not found")
+    db.execute("DELETE FROM trades WHERE id = ?", (trade_id,))
+    db.commit()
+    return Trade(**dict(existing))
+
+if __name__ == "__main__":
+    uvicorn.run("backend.app.main:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
## Summary
- build FastAPI app with SQLite storage and CRUD routes for /trades
- expose uvicorn entry point
- document backend start-up commands

## Testing
- `python -m py_compile backend/app/main.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b834773d68832d9091a304f6726806