### PR TITLE
Add Celery analytics task and worker docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ pip install fastapi uvicorn
 uvicorn backend.app.main:app --reload
 ```
 
+### Background Worker
+Install Celery and run the worker (requires a running Redis instance). The
+connection is configurable via the `CELERY_BROKER_URL` and
+`CELERY_RESULT_BACKEND` environment variables (defaults to
+`redis://localhost:6379/0`):
+```
+pip install celery redis
+celery -A backend.celery.celery_app worker --loglevel=info
+```
+
+Trigger analytics recalculation through the API:
+```
+curl -X POST http://localhost:8000/analytics/recalculate
+```
+
 ### Frontend
 ```
 npm install

--- a/backend/celery.py
+++ b/backend/celery.py
@@ -1,0 +1,25 @@
+import os
+import asyncio
+from typing import Any, Dict
+
+from celery import Celery
+
+from .db import get_trades
+
+CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/0")
+
+celery_app = Celery(
+    "trade_tracker", broker=CELERY_BROKER_URL, backend=CELERY_RESULT_BACKEND
+)
+
+@celery_app.task(name="recalculate_trade_analytics")
+def recalculate_trade_analytics() -> Dict[str, Any]:
+    """Recompute simple trade analytics.
+
+    This example aggregates the total quantity and number of trades
+    currently stored in the database.
+    """
+    trades = asyncio.run(get_trades())
+    total_qty = sum(record["qty"] for record in trades)
+    return {"trade_count": len(trades), "total_qty": total_qty}

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from typing import List
 
 from .db import create_trade, get_trades, update_trade, delete_trade, init_db
 from .models import Trade
+from .celery import recalculate_trade_analytics
 
 app = FastAPI()
 
@@ -28,3 +29,9 @@ async def update_trade_route(trade_id: int, trade: Trade) -> None:
 @app.delete("/trades/{trade_id}")
 async def delete_trade_route(trade_id: int) -> None:
     await delete_trade(trade_id)
+
+
+@app.post("/analytics/recalculate")
+async def recalc_trade_analytics_route() -> dict:
+    task = recalculate_trade_analytics.delay()
+    return {"task_id": task.id}


### PR DESCRIPTION
## Summary
- configure Celery with Redis broker/result backend
- add example trade analytics task and API trigger
- document running Celery worker and calling analytics endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8377c037c832db5d95642585358eb