### PR TITLE
feat: add clerk authentication

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2,29 +2,40 @@ import { Trade } from './types';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
 
-export async function fetchTrades(): Promise<Trade[]> {
-  const res = await fetch(`${API_BASE}/trades`);
+export async function fetchTrades(token: string): Promise<Trade[]> {
+  const res = await fetch(`${API_BASE}/trades`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
   if (!res.ok) throw new Error('Failed to load trades');
   return res.json();
 }
 
-export async function createTrade(trade: Trade): Promise<void> {
+export async function createTrade(trade: Trade, token: string): Promise<void> {
   await fetch(`${API_BASE}/trades`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
     body: JSON.stringify(trade),
   });
 }
 
-export async function updateTrade(trade: Trade): Promise<void> {
+export async function updateTrade(trade: Trade, token: string): Promise<void> {
   if (!trade.id) throw new Error('Trade id required for update');
   await fetch(`${API_BASE}/trades/${trade.id}`, {
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
     body: JSON.stringify(trade),
   });
 }
 
-export async function deleteTrade(id: number): Promise<void> {
-  await fetch(`${API_BASE}/trades/${id}`, { method: 'DELETE' });
+export async function deleteTrade(id: number, token: string): Promise<void> {
+  await fetch(`${API_BASE}/trades/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "14.1.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "@clerk/nextjs": "^4.27.0"
   },
   "devDependencies": {
     "typescript": "5.0.4",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,10 @@
+import type { AppProps } from 'next/app';
+import { ClerkProvider } from '@clerk/nextjs';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <ClerkProvider publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}>
+      <Component {...pageProps} />
+    </ClerkProvider>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { SignedIn, SignedOut, RedirectToSignIn, useAuth } from '@clerk/nextjs';
 import TradeForm from '../components/TradeForm';
 import TradeTable from '../components/TradeTable';
 import { Trade } from '../lib/types';
@@ -7,21 +8,26 @@ import { fetchTrades, createTrade, updateTrade, deleteTrade } from '../lib/api';
 export default function Home() {
   const [trades, setTrades] = useState<Trade[]>([]);
   const [editing, setEditing] = useState<Trade | null>(null);
+  const { getToken } = useAuth();
 
   useEffect(() => {
     loadTrades();
   }, []);
 
   async function loadTrades() {
-    const data = await fetchTrades();
+    const token = await getToken();
+    if (!token) return;
+    const data = await fetchTrades(token);
     setTrades(data);
   }
 
   async function handleSave(trade: Trade) {
+    const token = await getToken();
+    if (!token) return;
     if (editing) {
-      await updateTrade({ ...trade, id: editing.id });
+      await updateTrade({ ...trade, id: editing.id }, token);
     } else {
-      await createTrade(trade);
+      await createTrade(trade, token);
     }
     setEditing(null);
     await loadTrades();
@@ -32,7 +38,9 @@ export default function Home() {
   }
 
   async function handleDelete(id: number) {
-    await deleteTrade(id);
+    const token = await getToken();
+    if (!token) return;
+    await deleteTrade(id, token);
     await loadTrades();
   }
 
@@ -41,11 +49,18 @@ export default function Home() {
   }
 
   return (
-    <div>
-      <h1>Trade Tracker</h1>
-      <TradeForm initialTrade={editing} onSave={handleSave} onReset={handleReset} />
-      <h2>Trades</h2>
-      <TradeTable trades={trades} onEdit={handleEdit} onDelete={handleDelete} />
-    </div>
+    <>
+      <SignedIn>
+        <div>
+          <h1>Trade Tracker</h1>
+          <TradeForm initialTrade={editing} onSave={handleSave} onReset={handleReset} />
+          <h2>Trades</h2>
+          <TradeTable trades={trades} onEdit={handleEdit} onDelete={handleDelete} />
+        </div>
+      </SignedIn>
+      <SignedOut>
+        <RedirectToSignIn />
+      </SignedOut>
+    </>
   );
 }

--- a/frontend/pages/sign-in/[[...index]].tsx
+++ b/frontend/pages/sign-in/[[...index]].tsx
@@ -1,0 +1,5 @@
+import { SignIn } from '@clerk/nextjs';
+
+export default function SignInPage() {
+  return <SignIn />;
+}


### PR DESCRIPTION
## Summary
- install Clerk SDK and wrap app in ClerkProvider
- guard routes with SignedIn/SignedOut and redirect to sign in page
- send Clerk tokens with API requests for backend verification

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b83bd020a8832d8c271f5993855900