### PR TITLE
Add multi-leg trade support with attachments and metrics

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Generator
 import sqlite3
 from pathlib import Path
 import uvicorn
+import json
 
 from backend.analytics.metrics import compute_trade_metrics
 
@@ -31,6 +32,13 @@ def get_db() -> Generator[sqlite3.Connection, None, None]:
 def on_startup() -> None:
     init_db()
 
+class Leg(BaseModel):
+    symbol: str
+    side: str
+    qty: float
+    price: float
+
+
 class TradeBase(BaseModel):
     symbol: str
     side: str
@@ -42,6 +50,8 @@ class TradeBase(BaseModel):
     fees: Optional[float] = None
     tags: Optional[str] = None
     notes: Optional[str] = None
+    legs: Optional[List[Leg]] = None
+    attachment_url: Optional[str] = None
 
 class TradeCreate(TradeBase):
     pass
@@ -57,6 +67,8 @@ class TradeUpdate(BaseModel):
     fees: Optional[float] = None
     tags: Optional[str] = None
     notes: Optional[str] = None
+    legs: Optional[List[Leg]] = None
+    attachment_url: Optional[str] = None
 
 class Trade(TradeBase):
     id: int
@@ -64,14 +76,20 @@ class Trade(TradeBase):
 @app.get("/trades", response_model=List[Trade])
 def list_trades(db: sqlite3.Connection = Depends(get_db)) -> List[Trade]:
     rows = db.execute("SELECT * FROM trades").fetchall()
-    return [Trade(**dict(row)) for row in rows]
+    result = []
+    for row in rows:
+        data = dict(row)
+        if data.get("legs"):
+            data["legs"] = json.loads(data["legs"])
+        result.append(Trade(**data))
+    return result
 
 @app.post("/trades", response_model=Trade, status_code=201)
 def create_trade(trade: TradeCreate, db: sqlite3.Connection = Depends(get_db)) -> Trade:
     cursor = db.execute(
         """
-        INSERT INTO trades (symbol, side, qty, entry_price, entry_time, exit_price, exit_time, fees, tags, notes)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO trades (symbol, side, qty, entry_price, entry_time, exit_price, exit_time, fees, tags, notes, legs, attachment_url)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             trade.symbol,
@@ -84,10 +102,13 @@ def create_trade(trade: TradeCreate, db: sqlite3.Connection = Depends(get_db)) -
             trade.fees,
             trade.tags,
             trade.notes,
+            json.dumps([leg.dict() for leg in trade.legs]) if trade.legs else None,
+            trade.attachment_url,
         ),
     )
     db.commit()
-    return Trade(id=cursor.lastrowid, **trade.dict())
+    data = trade.dict()
+    return Trade(id=cursor.lastrowid, **data)
 
 @app.put("/trades/{trade_id}", response_model=Trade)
 def update_trade(trade_id: int, trade: TradeUpdate, db: sqlite3.Connection = Depends(get_db)) -> Trade:
@@ -97,7 +118,7 @@ def update_trade(trade_id: int, trade: TradeUpdate, db: sqlite3.Connection = Dep
     data = {**dict(existing), **trade.dict(exclude_unset=True)}
     db.execute(
         """
-        UPDATE trades SET symbol=?, side=?, qty=?, entry_price=?, entry_time=?, exit_price=?, exit_time=?, fees=?, tags=?, notes=?
+        UPDATE trades SET symbol=?, side=?, qty=?, entry_price=?, entry_time=?, exit_price=?, exit_time=?, fees=?, tags=?, notes=?, legs=?, attachment_url=?
         WHERE id=?
         """,
         (
@@ -111,12 +132,17 @@ def update_trade(trade_id: int, trade: TradeUpdate, db: sqlite3.Connection = Dep
             data.get("fees"),
             data.get("tags"),
             data.get("notes"),
+            json.dumps([leg.dict() for leg in data.get("legs", [])]) if data.get("legs") else None,
+            data.get("attachment_url"),
             trade_id,
         ),
     )
     db.commit()
     updated = db.execute("SELECT * FROM trades WHERE id = ?", (trade_id,)).fetchone()
-    return Trade(**dict(updated))
+    updated_data = dict(updated)
+    if updated_data.get("legs"):
+        updated_data["legs"] = json.loads(updated_data["legs"])
+    return Trade(**updated_data)
 
 
 @app.get("/trades/{trade_id}/analytics")
@@ -136,6 +162,27 @@ def delete_trade(trade_id: int, db: sqlite3.Connection = Depends(get_db)) -> Tra
     db.execute("DELETE FROM trades WHERE id = ?", (trade_id,))
     db.commit()
     return Trade(**dict(existing))
+
+
+@app.get("/analytics/summary")
+def analytics_summary(db: sqlite3.Connection = Depends(get_db)) -> dict:
+    rows = db.execute("SELECT * FROM trades").fetchall()
+    summary: dict[str, dict[str, float]] = {}
+    for row in rows:
+        trade = dict(row)
+        if trade.get("exit_price") is None:
+            continue
+        metrics = compute_trade_metrics(trade)
+        tags = [t.strip() for t in (trade.get("tags") or "").split(",") if t.strip()] or ["untagged"]
+        for tag in tags:
+            data = summary.setdefault(tag, {"pnl": 0.0, "return_pct": 0.0, "trades": 0})
+            data["pnl"] += metrics["pnl"]
+            data["return_pct"] += metrics["return_pct"]
+            data["trades"] += 1
+    for tag, data in summary.items():
+        if data["trades"]:
+            data["return_pct"] = data["return_pct"] / data["trades"]
+    return summary
 
 if __name__ == "__main__":
     uvicorn.run("backend.app.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/backend/db.py
+++ b/backend/db.py
@@ -21,8 +21,8 @@ async def create_trade(trade: Dict[str, Any]) -> int:
     pool = await init_db()
     query = (
         "INSERT INTO trades (id, symbol, side, qty, entry_price, entry_time, "
-        "exit_price, exit_time, fees, tags, notes)"
-        " VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11) RETURNING id"
+        "exit_price, exit_time, fees, tags, notes, legs, attachment_url)"
+        " VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13) RETURNING id"
     )
     async with pool.acquire() as conn:
         return await conn.fetchval(
@@ -38,6 +38,8 @@ async def create_trade(trade: Dict[str, Any]) -> int:
             trade.get("fees"),
             trade.get("tags"),
             trade.get("notes"),
+            trade.get("legs"),
+            trade.get("attachment_url"),
         )
 
 async def get_trades() -> List[asyncpg.Record]:
@@ -49,7 +51,7 @@ async def update_trade(trade_id: int, trade: Dict[str, Any]) -> None:
     pool = await init_db()
     query = (
         "UPDATE trades SET symbol=$1, side=$2, qty=$3, entry_price=$4, entry_time=$5,"
-        " exit_price=$6, exit_time=$7, fees=$8, tags=$9, notes=$10 WHERE id=$11"
+        " exit_price=$6, exit_time=$7, fees=$8, tags=$9, notes=$10, legs=$11, attachment_url=$12 WHERE id=$13"
     )
     async with pool.acquire() as conn:
         await conn.execute(
@@ -64,6 +66,8 @@ async def update_trade(trade_id: int, trade: Dict[str, Any]) -> None:
             trade.get("fees"),
             trade.get("tags"),
             trade.get("notes"),
+            trade.get("legs"),
+            trade.get("attachment_url"),
             trade_id,
         )
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,13 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
+
+
+class Leg(BaseModel):
+    symbol: str
+    side: str
+    qty: float
+    price: float
+
 
 class Trade(BaseModel):
     id: int
@@ -13,3 +21,5 @@ class Trade(BaseModel):
     fees: Optional[float] = None
     tags: Optional[str] = None
     notes: Optional[str] = None
+    legs: Optional[List[Leg]] = None
+    attachment_url: Optional[str] = None

--- a/frontend/components/StrategyMetrics.tsx
+++ b/frontend/components/StrategyMetrics.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { StrategyMetrics } from '../lib/types';
+import { fetchStrategyMetrics } from '../lib/api';
+
+export default function StrategyMetrics() {
+  const [metrics, setMetrics] = useState<StrategyMetrics>({});
+
+  useEffect(() => {
+    async function load() {
+      const data = await fetchStrategyMetrics();
+      setMetrics(data);
+    }
+    load();
+  }, []);
+
+  const tags = Object.keys(metrics);
+  if (tags.length === 0) return <div>No metrics available</div>;
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Strategy</th>
+          <th>Trades</th>
+          <th>PNL</th>
+          <th>Return %</th>
+        </tr>
+      </thead>
+      <tbody>
+        {tags.map(tag => (
+          <tr key={tag}>
+            <td>{tag}</td>
+            <td>{metrics[tag].trades}</td>
+            <td>{metrics[tag].pnl.toFixed(2)}</td>
+            <td>{(metrics[tag].return_pct * 100).toFixed(2)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,4 @@
-import { Trade } from './types';
+import { Trade, StrategyMetrics } from './types';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
 
@@ -27,4 +27,10 @@ export async function updateTrade(trade: Trade): Promise<void> {
 
 export async function deleteTrade(id: number): Promise<void> {
   await fetch(`${API_BASE}/trades/${id}`, { method: 'DELETE' });
+}
+
+export async function fetchStrategyMetrics(): Promise<StrategyMetrics> {
+  const res = await fetch(`${API_BASE}/analytics/summary`);
+  if (!res.ok) throw new Error('Failed to load metrics');
+  return res.json();
 }

--- a/frontend/lib/storage.ts
+++ b/frontend/lib/storage.ts
@@ -1,0 +1,13 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+const client = createClient(supabaseUrl, supabaseKey);
+
+export async function uploadAttachment(file: File): Promise<string> {
+  const filePath = `${Date.now()}_${file.name}`;
+  const { error } = await client.storage.from('attachments').upload(filePath, file);
+  if (error) throw error;
+  const { data } = client.storage.from('attachments').getPublicUrl(filePath);
+  return data.publicUrl;
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1,3 +1,10 @@
+export interface Leg {
+  symbol: string;
+  side: 'buy' | 'sell';
+  qty: number;
+  price: number;
+}
+
 export interface Trade {
   id?: number;
   symbol: string;
@@ -10,4 +17,14 @@ export interface Trade {
   fees?: number | null;
   tags?: string;
   notes?: string;
+  legs?: Leg[];
+  attachment_url?: string | null;
+}
+
+export interface StrategyMetrics {
+  [tag: string]: {
+    pnl: number;
+    return_pct: number;
+    trades: number;
+  };
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "14.1.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "2.39.4"
   },
   "devDependencies": {
     "typescript": "5.0.4",

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import TradeForm from '../components/TradeForm';
 import TradeTable from '../components/TradeTable';
+import StrategyMetrics from '../components/StrategyMetrics';
 import { Trade } from '../lib/types';
 import { fetchTrades, createTrade, updateTrade, deleteTrade } from '../lib/api';
 
@@ -46,6 +47,8 @@ export default function Home() {
       <TradeForm initialTrade={editing} onSave={handleSave} onReset={handleReset} />
       <h2>Trades</h2>
       <TradeTable trades={trades} onEdit={handleEdit} onDelete={handleDelete} />
+      <h2>Strategy Metrics</h2>
+      <StrategyMetrics />
     </div>
   );
 }

--- a/schema.sql
+++ b/schema.sql
@@ -10,5 +10,7 @@ CREATE TABLE IF NOT EXISTS trades (
   exit_time TEXT,
   fees REAL,
   tags TEXT,
-  notes TEXT
+  notes TEXT,
+  legs TEXT,
+  attachment_url TEXT
 );

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -58,3 +58,23 @@ def test_trade_analytics_endpoint():
     data = analytics.json()
     assert np.isclose(data["pnl"], 98.0)
     assert np.isclose(data["return_pct"], 0.098)
+
+
+def test_analytics_summary_endpoint():
+    client = TestClient(app)
+    base = {
+        "side": "buy",
+        "qty": 1,
+        "entry_price": 100,
+        "entry_time": "2024-01-01T00:00:00Z",
+        "exit_price": 105,
+        "exit_time": "2024-01-02T00:00:00Z",
+        "fees": 0,
+    }
+    client.post("/trades", json={"symbol": "AAA", **base, "tags": "strat"})
+    client.post("/trades", json={"symbol": "BBB", **base, "tags": "strat"})
+
+    summary = client.get("/analytics/summary")
+    assert summary.status_code == 200
+    data = summary.json()
+    assert data["strat"]["trades"] == 2


### PR DESCRIPTION
## Summary
- allow trades to include multiple legs and optional file attachment uploaded to Supabase storage
- surface aggregated strategy metrics via new analytics summary endpoint and UI component
- extend API models and schema for legs and attachment URLs

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fsupabase-js)*
- `pip install numpy pandas fastapi uvicorn` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b83d2e4efc832d8fe369fa0e28753c